### PR TITLE
Make sure to show the scale buttons under content view

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -89,8 +89,6 @@ namespace ManHelper
         //internal Gtk.ScrolledWindow scrolled;
         [GtkChild]
         private unowned Gtk.Box box_mainwin;
-        [GtkChild]
-        private unowned Gtk.Box box_page_zoomer;
 
         internal string init_font_family = null;
         internal uint32 init_font_size = 0;
@@ -113,7 +111,7 @@ namespace ManHelper
 
             /* pack the page_zoomer after Webkit view */
             this.page_zoomer = new PageZoomer(this);
-            box_page_zoomer.pack_start(this.page_zoomer,true,true,0);
+            box_mainwin.pack_start(this.page_zoomer,false,false,0);
 
             var bookmarks_dirpath = app.bookmarks_parent_dir+app.bookmarks_directory;
             this.app.bookmarks_db = new DataBase(bookmarks_dirpath,app.bookmarks_filename);

--- a/ui/manhelper.ui
+++ b/ui/manhelper.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="adjustment_font">
@@ -45,7 +45,7 @@
     <property name="window_position">mouse</property>
     <property name="default_width">1024</property>
     <property name="default_height">1280</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -183,19 +183,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box_page_zoomer">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
+              <placeholder/>
             </child>
             <child>
               <object class="GtkBox">

--- a/ui/page_zoomer.ui
+++ b/ui/page_zoomer.ui
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image_down">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-down</property>
+    <property name="stock">gtk-zoom-out</property>
   </object>
   <object class="GtkImage" id="image_fit">
     <property name="visible">True</property>
@@ -15,7 +15,7 @@
   <object class="GtkImage" id="image_up">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-up</property>
+    <property name="stock">gtk-zoom-in</property>
   </object>
   <template class="ManHelperPageZoomer" parent="GtkBox">
     <property name="width_request">200</property>
@@ -25,6 +25,7 @@
       <object class="GtkEntry" id="entry_zoom">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
+        <property name="halign">end</property>
         <property name="max_length">3</property>
         <property name="width_chars">3</property>
         <property name="max_width_chars">3</property>


### PR DESCRIPTION
I assume scales maybe placed in the bottom of the window instead of in the top in many other apps that have them. Also use the correct icons for zoom in/out while I'm here

## Before
![Screenshot from 2021-11-14 14-16-15](https://user-images.githubusercontent.com/26003928/141668640-20ceea84-c403-42e6-b0c1-a3cfba97058e.png)

## After
![Screenshot from 2021-11-14 14-15-35](https://user-images.githubusercontent.com/26003928/141668647-7d70ea15-3f37-4282-94b6-4582e635b8f9.png)
